### PR TITLE
docs: make fonts for html docs non-blocking

### DIFF
--- a/.milpa/commands/itself/docs/html.sh
+++ b/.milpa/commands/itself/docs/html.sh
@@ -23,6 +23,7 @@ function generate_content_folder() {
 
   cat - <(tail -n +2 "$MILPA_ROOT/CHANGELOG.md") > "$content/help/docs/milpa/changelog.md" <<YAML
 ---
+description: "Changelog entries for every released version"
 weight: 100
 ---
 

--- a/.milpa/docs/milpa/alternatives.md
+++ b/.milpa/docs/milpa/alternatives.md
@@ -1,6 +1,7 @@
 ---
 title: Why use milpa
-weight: 50
+description: Use-cases and alternatives when using milpa
+weight: 2
 ---
 
 I built milpa with a few use cases in mind:

--- a/.milpa/docs/milpa/command/index.md
+++ b/.milpa/docs/milpa/command/index.md
@@ -2,6 +2,7 @@
 related-docs: [milpa/environment, milpa/command/spec]
 related-commands: ["itself create"]
 weight: 15
+description: Commands overview
 ---
 `milpa` can run two types of commands:
 

--- a/.milpa/docs/milpa/command/spec.md
+++ b/.milpa/docs/milpa/command/spec.md
@@ -1,6 +1,7 @@
 ---
 related-docs: [milpa/command/environment, milpa/repo/index, milpa/repo/docs]
 related-commands: ["itself create", "itself docs generate"]
+index: Command specs
 ---
 Command specs go along with your scripts and help inform `milpa` of what its input should look like. Based on it, `milpa` will produce help pages and autocompletions, and may validate the arguments to your command.
 

--- a/.milpa/docs/milpa/environment.md
+++ b/.milpa/docs/milpa/environment.md
@@ -1,5 +1,6 @@
 ---
 related-docs: [utils/log, command/environment]
+description: An overview of all milpa environment variables
 weight: 10
 ---
 There's a few environment variables that control the behavior of `milpa`.

--- a/.milpa/docs/milpa/quick-guide.md
+++ b/.milpa/docs/milpa/quick-guide.md
@@ -1,5 +1,6 @@
 ---
 title: Getting started
+description: A quick guide to getting started with milpa
 weight: 1
 ---
 

--- a/.milpa/docs/milpa/repo/docs.md
+++ b/.milpa/docs/milpa/repo/docs.md
@@ -1,3 +1,9 @@
-`!milpa` can render any markdown-formatted documents stored at `.milpa/docs` to the terminal and browser. Files must be named with an `.md` extension and may exist at any folder depth. Files named `.milpa/docs/whatever/index.md` may be displayed by running either `milpa help docs whatever` or `milpa help docs whatever index`
+---
+description: Render markdown docs to the terminal or browser
+---
+
+`milpa` can render any markdown-formatted documents stored at `.milpa/docs` to the terminal and browser. Files must be named with an `.md` extension and may exist at any folder depth. Files named `.milpa/docs/whatever/index.md` may be displayed by running either `milpa help docs whatever` or `milpa help docs whatever index`
 
 Same docs are rendered to HTML, using the [`milpa itself docs html`](/.milpa/commands/itself/docs) command.
+
+These docs are brought to you courtesy of the recursive department of departamental recursiveness.

--- a/.milpa/docs/milpa/repo/hooks.md
+++ b/.milpa/docs/milpa/repo/hooks.md
@@ -1,3 +1,7 @@
+---
+description: Hook points for milpa commands
+---
+
 `milpa` provides a couple of hook points for you to tweak the behavior of your shell and your repo's commands. Hooks for your repo must be placed in the `.milpa/hooks` folder.
 
 ## `shell-init(.sh)`

--- a/.milpa/docs/milpa/repo/index.md
+++ b/.milpa/docs/milpa/repo/index.md
@@ -2,6 +2,7 @@
 related-docs: ["milpa commands", "milpa environment"]
 related-commands: ["itself create"]
 weight: 10
+description: Repository layout
 ---
 Repositories are folders that contain a `.milpa` folder within. Use the `MILPA_PATH` environment variable to tell `milpa` where to look for repos (see [`milpa itself docs environment`](/.milpa/docs/milpa/environment.md#MILPA_PATH)). By default, `milpa` will prepend any folder named `.milpa` at the top-level of a git repository to the `MILPA_PATH`.
 

--- a/.milpa/docs/milpa/util/index.md
+++ b/.milpa/docs/milpa/util/index.md
@@ -1,3 +1,7 @@
+---
+description: Milpa comes with a shell library full of functions
+weight: 20
+---
 `milpa` scripts that are written with bash may use any of the built-in or repo-specific shell utilities under the `.milpa/utils` folder.
 
 ## Usage

--- a/.milpa/docs/milpa/util/log.md
+++ b/.milpa/docs/milpa/util/log.md
@@ -1,3 +1,7 @@
+---
+description: Functions related to output
+---
+
 The `log` util contains shell functions related to output of informational messages. This utility is **loaded by default**.
 
 If [`TERM`](https://linux.die.net/man/7/term) is not set, then it'll default to `xterm-color`.

--- a/.milpa/docs/milpa/util/repo.md
+++ b/.milpa/docs/milpa/util/repo.md
@@ -1,3 +1,7 @@
+---
+description: Functions related to milpa repositories
+---
+
 The `repo` util contains shell functions related to milpa repositories
 
 ## Functions

--- a/.milpa/docs/milpa/util/shell.md
+++ b/.milpa/docs/milpa/util/shell.md
@@ -1,3 +1,7 @@
+---
+description: Functions related to shell-init hooks
+---
+
 The `repo` util contains shell functions useful during [`shell-init`](/.milpa/help/docs/milpa/repo/hooks/#shell-initsh) hook scripts, where it's loaded by default.
 
 These functions are compatible with shells whose name ends in "sh" and are POSIX-compliant, and the fish shell.

--- a/repos/internal/docs/.template/config.toml
+++ b/repos/internal/docs/.template/config.toml
@@ -21,7 +21,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 
 # Highlighting config
 pygmentsCodeFences = true
-pygmentsUseClasses = false
+pygmentsUseClasses = true
 # Use the new Chroma Go highlighter in Hugo.
 pygmentsUseClassic = false
 #pygmentsOptions = "linenos=table"

--- a/repos/internal/docs/.template/theme/assets/css/highlight-dark.css
+++ b/repos/internal/docs/.template/theme/assets/css/highlight-dark.css
@@ -1,0 +1,84 @@
+@media screen and (prefers-color-scheme: dark) {
+/* Background */ .chroma { color: #f8f8f2; background-color: #132b17 }
+/* Other */ .chroma .x {  }
+/* Error */ .chroma .err { color: #960050; background-color: #1e0010 }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
+/* LineHighlight */ .chroma .hl { display: block; width: 100%;background-color: #ffffcc }
+/* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* Keyword */ .chroma .k { color: #66d9ef }
+/* KeywordConstant */ .chroma .kc { color: #66d9ef }
+/* KeywordDeclaration */ .chroma .kd { color: #66d9ef }
+/* KeywordNamespace */ .chroma .kn { color: #f92672 }
+/* KeywordPseudo */ .chroma .kp { color: #66d9ef }
+/* KeywordReserved */ .chroma .kr { color: #66d9ef }
+/* KeywordType */ .chroma .kt { color: #66d9ef }
+/* Name */ .chroma .n {  }
+/* NameAttribute */ .chroma .na { color: #a6e22e }
+/* NameBuiltin */ .chroma .nb {  }
+/* NameBuiltinPseudo */ .chroma .bp {  }
+/* NameClass */ .chroma .nc { color: #a6e22e }
+/* NameConstant */ .chroma .no { color: #66d9ef }
+/* NameDecorator */ .chroma .nd { color: #a6e22e }
+/* NameEntity */ .chroma .ni {  }
+/* NameException */ .chroma .ne { color: #a6e22e }
+/* NameFunction */ .chroma .nf { color: #a6e22e }
+/* NameFunctionMagic */ .chroma .fm {  }
+/* NameLabel */ .chroma .nl {  }
+/* NameNamespace */ .chroma .nn {  }
+/* NameOther */ .chroma .nx { color: #a6e22e }
+/* NameProperty */ .chroma .py {  }
+/* NameTag */ .chroma .nt { color: #f92672 }
+/* NameVariable */ .chroma .nv {  }
+/* NameVariableClass */ .chroma .vc {  }
+/* NameVariableGlobal */ .chroma .vg {  }
+/* NameVariableInstance */ .chroma .vi {  }
+/* NameVariableMagic */ .chroma .vm {  }
+/* Literal */ .chroma .l { color: #ae81ff }
+/* LiteralDate */ .chroma .ld { color: #e6db74 }
+/* LiteralString */ .chroma .s { color: #e6db74 }
+/* LiteralStringAffix */ .chroma .sa { color: #e6db74 }
+/* LiteralStringBacktick */ .chroma .sb { color: #e6db74 }
+/* LiteralStringChar */ .chroma .sc { color: #e6db74 }
+/* LiteralStringDelimiter */ .chroma .dl { color: #e6db74 }
+/* LiteralStringDoc */ .chroma .sd { color: #e6db74 }
+/* LiteralStringDouble */ .chroma .s2 { color: #e6db74 }
+/* LiteralStringEscape */ .chroma .se { color: #ae81ff }
+/* LiteralStringHeredoc */ .chroma .sh { color: #e6db74 }
+/* LiteralStringInterpol */ .chroma .si { color: #e6db74 }
+/* LiteralStringOther */ .chroma .sx { color: #e6db74 }
+/* LiteralStringRegex */ .chroma .sr { color: #e6db74 }
+/* LiteralStringSingle */ .chroma .s1 { color: #e6db74 }
+/* LiteralStringSymbol */ .chroma .ss { color: #e6db74 }
+/* LiteralNumber */ .chroma .m { color: #ae81ff }
+/* LiteralNumberBin */ .chroma .mb { color: #ae81ff }
+/* LiteralNumberFloat */ .chroma .mf { color: #ae81ff }
+/* LiteralNumberHex */ .chroma .mh { color: #ae81ff }
+/* LiteralNumberInteger */ .chroma .mi { color: #ae81ff }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #ae81ff }
+/* LiteralNumberOct */ .chroma .mo { color: #ae81ff }
+/* Operator */ .chroma .o { color: #f92672 }
+/* OperatorWord */ .chroma .ow { color: #f92672 }
+/* Punctuation */ .chroma .p {  }
+/* Comment */ .chroma .c { color: #75715e }
+/* CommentHashbang */ .chroma .ch { color: #75715e }
+/* CommentMultiline */ .chroma .cm { color: #75715e }
+/* CommentSingle */ .chroma .c1 { color: #75715e }
+/* CommentSpecial */ .chroma .cs { color: #75715e }
+/* CommentPreproc */ .chroma .cp { color: #75715e }
+/* CommentPreprocFile */ .chroma .cpf { color: #75715e }
+/* Generic */ .chroma .g {  }
+/* GenericDeleted */ .chroma .gd { color: #f92672 }
+/* GenericEmph */ .chroma .ge { font-style: italic }
+/* GenericError */ .chroma .gr {  }
+/* GenericHeading */ .chroma .gh {  }
+/* GenericInserted */ .chroma .gi { color: #a6e22e }
+/* GenericOutput */ .chroma .go {  }
+/* GenericPrompt */ .chroma .gp {  }
+/* GenericStrong */ .chroma .gs { font-weight: bold }
+/* GenericSubheading */ .chroma .gu { color: #75715e }
+/* GenericTraceback */ .chroma .gt {  }
+/* GenericUnderline */ .chroma .gl {  }
+/* TextWhitespace */ .chroma .w {  }
+}

--- a/repos/internal/docs/.template/theme/assets/css/highlight-light.css
+++ b/repos/internal/docs/.template/theme/assets/css/highlight-light.css
@@ -1,0 +1,84 @@
+@media screen and (prefers-color-scheme: light) {
+/* Background */ .chroma { background-color: rgba(65, 80, 66, 0.1) }
+/* Other */ .chroma .x {  }
+/* Error */ .chroma .err { color: #000000 }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
+/* LineHighlight */ .chroma .hl { display: block; width: 100%;background-color: #ffffcc }
+/* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* Keyword */ .chroma .k { color: #a90d91 }
+/* KeywordConstant */ .chroma .kc { color: #a90d91 }
+/* KeywordDeclaration */ .chroma .kd { color: #a90d91 }
+/* KeywordNamespace */ .chroma .kn { color: #a90d91 }
+/* KeywordPseudo */ .chroma .kp { color: #a90d91 }
+/* KeywordReserved */ .chroma .kr { color: #a90d91 }
+/* KeywordType */ .chroma .kt { color: #a90d91 }
+/* Name */ .chroma .n { color: #000000 }
+/* NameAttribute */ .chroma .na { color: #836c28 }
+/* NameBuiltin */ .chroma .nb { color: #a90d91 }
+/* NameBuiltinPseudo */ .chroma .bp { color: #5b269a }
+/* NameClass */ .chroma .nc { color: #3f6e75 }
+/* NameConstant */ .chroma .no { color: #000000 }
+/* NameDecorator */ .chroma .nd { color: #000000 }
+/* NameEntity */ .chroma .ni { color: #000000 }
+/* NameException */ .chroma .ne { color: #000000 }
+/* NameFunction */ .chroma .nf { color: #000000 }
+/* NameFunctionMagic */ .chroma .fm { color: #000000 }
+/* NameLabel */ .chroma .nl { color: #000000 }
+/* NameNamespace */ .chroma .nn { color: #000000 }
+/* NameOther */ .chroma .nx { color: #000000 }
+/* NameProperty */ .chroma .py { color: #000000 }
+/* NameTag */ .chroma .nt { color: #000000 }
+/* NameVariable */ .chroma .nv { color: #000000 }
+/* NameVariableClass */ .chroma .vc { color: #000000 }
+/* NameVariableGlobal */ .chroma .vg { color: #000000 }
+/* NameVariableInstance */ .chroma .vi { color: #000000 }
+/* NameVariableMagic */ .chroma .vm { color: #000000 }
+/* Literal */ .chroma .l { color: #1c01ce }
+/* LiteralDate */ .chroma .ld { color: #1c01ce }
+/* LiteralString */ .chroma .s { color: #12731D }
+/* LiteralStringAffix */ .chroma .sa { color: #12731D }
+/* LiteralStringBacktick */ .chroma .sb { color: #12731D }
+/* LiteralStringChar */ .chroma .sc { color: #2300ce }
+/* LiteralStringDelimiter */ .chroma .dl { color: #12731D }
+/* LiteralStringDoc */ .chroma .sd { color: #12731D }
+/* LiteralStringDouble */ .chroma .s2 { color: #12731D }
+/* LiteralStringEscape */ .chroma .se { color: #12731D }
+/* LiteralStringHeredoc */ .chroma .sh { color: #12731D }
+/* LiteralStringInterpol */ .chroma .si { color: #12731D }
+/* LiteralStringOther */ .chroma .sx { color: #12731D }
+/* LiteralStringRegex */ .chroma .sr { color: #12731D }
+/* LiteralStringSingle */ .chroma .s1 { color: #12731D }
+/* LiteralStringSymbol */ .chroma .ss { color: #12731D }
+/* LiteralNumber */ .chroma .m { color: #1c01ce }
+/* LiteralNumberBin */ .chroma .mb { color: #1c01ce }
+/* LiteralNumberFloat */ .chroma .mf { color: #1c01ce }
+/* LiteralNumberHex */ .chroma .mh { color: #1c01ce }
+/* LiteralNumberInteger */ .chroma .mi { color: #1c01ce }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #1c01ce }
+/* LiteralNumberOct */ .chroma .mo { color: #1c01ce }
+/* Operator */ .chroma .o { color: #000000 }
+/* OperatorWord */ .chroma .ow { color: #000000 }
+/* Punctuation */ .chroma .p {  }
+/* Comment */ .chroma .c { color: #5D7260 }
+/* CommentHashbang */ .chroma .ch { color: #5D7260 }
+/* CommentMultiline */ .chroma .cm { color: #5D7260 }
+/* CommentSingle */ .chroma .c1 { color: #5D7260 }
+/* CommentSpecial */ .chroma .cs { color: #5D7260 }
+/* CommentPreproc */ .chroma .cp { color: #633820 }
+/* CommentPreprocFile */ .chroma .cpf { color: #633820 }
+/* Generic */ .chroma .g {  }
+/* GenericDeleted */ .chroma .gd {  }
+/* GenericEmph */ .chroma .ge {  }
+/* GenericError */ .chroma .gr {  }
+/* GenericHeading */ .chroma .gh {  }
+/* GenericInserted */ .chroma .gi {  }
+/* GenericOutput */ .chroma .go {  }
+/* GenericPrompt */ .chroma .gp {  }
+/* GenericStrong */ .chroma .gs {  }
+/* GenericSubheading */ .chroma .gu {  }
+/* GenericTraceback */ .chroma .gt {  }
+/* GenericUnderline */ .chroma .gl {  }
+/* TextWhitespace */ .chroma .w {  }
+}

--- a/repos/internal/docs/.template/theme/assets/css/index.css
+++ b/repos/internal/docs/.template/theme/assets/css/index.css
@@ -5,7 +5,7 @@ html, body {
 }
 
 body {
-  font-family: "Playfair Display";
+  font-family: "Playfair Display", Georgia, serif;
   font-size: 16px;
   color: #2B3C2D;
   background-color: #dff4d4
@@ -15,7 +15,7 @@ header {
   color: #CEFCD3;
   background: #2B3C2D;
   margin: 0;
-  font-family: "Fira Code";
+  font-family: "Fira Code", monospace;
   font-weight: bold;
   display: flex;
   position: sticky;
@@ -58,7 +58,7 @@ header .emoji-maiz:hover::before {
   background: rgba(255,255,255,.1);
   border: none;
   color: #CEFCD3;
-  font-family: "Fira Code";
+  font-family: "Fira Code", monospace;
   font-weight: bold;
   flex: auto;
   transition: all .3s ease-in-out;
@@ -134,7 +134,7 @@ header .emoji-maiz:hover::before {
 }
 
 #commands ul {
-  font-family: "Fira Code";
+  font-family: "Fira Code", monospace;
 }
 
 #sidebar ul {
@@ -169,7 +169,7 @@ header .emoji-maiz:hover::before {
 }
 
 .heading-anchor {
-  font-family: "Fira Code";
+  font-family: "Fira Code", monospace;
   font-weight: 400;
   font-size: .7em;
   opacity: .7;
@@ -189,7 +189,7 @@ header .emoji-maiz:hover::before {
 }
 
 #content pre, #content code {
-  font-family: "Fira Code";
+  font-family: "Fira Code", monospace;
   font-size: .9em;
   line-height: 1.2em;
 }
@@ -203,10 +203,6 @@ header .emoji-maiz:hover::before {
   border-radius: 3px;
   color: #12731D;
   padding:0 .3em;
-}
-
-.highlight pre {
-  background-color: rgba(65, 80, 66, 0.1) !important
 }
 
 pre {
@@ -256,6 +252,7 @@ hr {
   z-index: 1000;
 }
 
+
 @media screen and (prefers-color-scheme: dark) {
   body {
     color: #96b452;
@@ -284,9 +281,6 @@ hr {
     background: #132b17;
   }
 
-  .highlight pre {
-    background-color: #132b17!important;
-  }
 }
 
 @media screen and (prefers-color-scheme: dark) and (max-width: 768px) {

--- a/repos/internal/docs/.template/theme/layouts/_default/_markup/render-heading.html
+++ b/repos/internal/docs/.template/theme/layouts/_default/_markup/render-heading.html
@@ -1,3 +1,3 @@
 <div class="content-header-wrapper">
-<h{{ .Level }} class="content-header" id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }}</h{{ .Level }}> <a aria-hidden="true" class="heading-anchor" href="#{{ .Anchor | safeURL }}">#</a>
+<h{{ .Level }} class="content-header" id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }}</h{{ .Level }}> <a aria-hidden="true" class="heading-anchor" href="#{{ .Anchor | safeURL }}" tabindex="-1">#</a>
 </div>

--- a/repos/internal/docs/.template/theme/layouts/partials/head.html
+++ b/repos/internal/docs/.template/theme/layouts/partials/head.html
@@ -1,17 +1,48 @@
 <head lang="en">
   <meta charset="utf-8">
   {{/* <base href="{{ .Site.BaseURL }}"> */}}
+  {{- $commandName := replace (trim .RelPermalink "/") "/" " " -}}
+  {{- $is404 := (eq .RelPermalink "/404.html") -}}
+  {{- $description := "FAIL" -}}
+  {{- if not .IsHome -}}
+  {{- if not $is404 -}}
+  {{- $description = .Description -}}
+  {{- else -}}
+  {{- $description = "Not found" -}}
+  {{- end -}}
+  {{- else -}}
+  {{ $description = "A tool to care for one's own garden of scripts" -}}
+  {{- end -}}
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="en" />
-  <meta property="og:title" content="{{ if not .IsHome }}{{ replace .RelPermalink "/" " " }}{{else}}milpa command line utility{{end}}" />
+  <meta property="og:title" content="{{ if not .IsHome }}{{ if not $is404 }}{{ $commandName }}{{else}}Not Found{{end}}{{- else -}}milpa command line utility{{- end -}}" />
   <meta property="og:site_name" content="🌽 milpa" />
-  <meta property="og:description" content="{{ .Description }}" />
+  <meta property="og:description" content="{{ $description }}" />
+  <meta name="description" content="{{ $description }}" />
   <meta property="og:url" content="{{ .Permalink }}" />
-  <title>milpa{{ if not .IsHome }} {{ replace .RelPermalink "/" " " }}{{end}}</title>
-  <link href="//fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;700&family=Playfair+Display:ital,wght@0,400;0,600;0,900;1,400;1,600;1,900&display=swap" rel="stylesheet">
-  {{ $style := resources.Get   "css/index.css" | minify | fingerprint }}
-  <link rel="stylesheet" href="{{ $style.Permalink }}"/>
+  <title>milpa{{ if not .IsHome }} {{ if not $is404 }}{{ $commandName }}{{else}}Not Found{{end}}{{end}}</title>
+  {{ $css := resources.Get "css/index.css" -}}
+  {{- $hlLight := resources.Get "css/highlight-light.css" -}}
+  {{- $hlDark := resources.Get "css/highlight-dark.css" -}}
+  {{- $style := slice $css $hlLight $hlDark | resources.Concat "css/bundle.css" | minify | fingerprint -}}
+  <link rel="stylesheet" href="{{ $style.RelPermalink }}"/>
+
   <link rel="canonical" href="{{ .Permalink }}">
+
+  {{/*
+
+  https://css-tricks.com/how-to-load-fonts-in-a-way-that-fights-fout-and-makes-lighthouse-happy/
+  https://fonts.gstatic.com is the font file origin
+  It may not have the same origin as the CSS file (https://fonts.googleapis.com)
+
+   */}}
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  {{/* <!-- We use the full link to the CSS file in the rest of the tags --> */}}
+  <link href="//fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;700&family=Playfair+Display:ital,wght@0,400;0,600;0,900;1,400;1,600;1,900&display=swap" rel="preload" as="style">
+  <link href="//fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;700&family=Playfair+Display:ital,wght@0,400;0,600;0,900;1,400;1,600;1,900&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+  <noscript>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;700&family=Playfair+Display:ital,wght@0,400;0,600;0,900;1,400;1,600;1,900&display=swap" />
+  </noscript>
 </head>

--- a/repos/internal/docs/.template/theme/layouts/partials/header.html
+++ b/repos/internal/docs/.template/theme/layouts/partials/header.html
@@ -9,9 +9,9 @@
     id="command-selector"
     value="{{ if not .IsHome }}{{ replace (trim .RelPermalink "/") "/" " " }}{{ end }}" />
   <datalist id="milpa-commands">
-    {{ range (union .Site.Home.Pages .Site.Home.Sections).ByWeight }}
+    {{ range (union .Site.Home.Pages .Site.Home.Sections).ByWeight -}}
     {{ template "command-autocomplete-list" . }}
-    {{ end }}
+    {{- end -}}
   </datalist>
   <button id="menu-toggle" aria-label="Toggle navigation menu"><svg version="1.1" viewBox="0 0 310 259.34" xmlns="http://www.w3.org/2000/svg"><title>Menu Icon</title><g transform="translate(10.016 -803.03)"><g fill="none" stroke="#000" stroke-linecap="round" stroke-width="49.336"><path d="m19.668 1032.7h250.65"/><path d="m19.668 932.69h250.65"/><path d="m19.668 832.69h250.65"/></g></g></svg></button>
 </header>
@@ -21,9 +21,9 @@
 {{- $subPages := (union .Pages .Sections).ByWeight -}}
 {{- $hasChildren := gt (len $subPages) 0 -}}
 <option value="{{ replace (trim .RelPermalink "/") "/" " " }}" />
-{{ if $hasChildren }}
-{{ range $subPages }}
+{{ if $hasChildren -}}
+{{- range $subPages -}}
 {{ template "command-autocomplete-list" .}}
-{{ end }}
-{{ end }}
-{{ end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
- add og/meta descriptions to docs
- nicer highlighting in light/dark modes

Gets us a mostly passing score from lighthouse/pagespeed insights/etc (can't get to a faster first contentful paint than 2.9s and i think it has to do with github pages).