### PR TITLE
rewrite autocompletion spec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,28 +1,38 @@
 linters-settings:
   gocyclo:
     min-complexity: 18
+  tagliatelle:
+    case:
+      rules:
+        yaml: kebab
 
 linters:
   fast: false
   enable:
     - deadcode
     - errcheck
-    # - exportloopref
+    - exportloopref
     - goconst
     - gocritic
     - gocyclo
+    - godot
+    - godox
     - gofmt
     - goimports
-    - revive
     - gosec
     - gosimple
     - govet
+    - ifshort
     - ineffassign
     - misspell
+    - nakedret
+    - nilerr
     - prealloc
+    - revive
     - staticcheck
     - structcheck
     - stylecheck
+    - tagliatelle
     - typecheck
     - unconvert
     - unparam

--- a/.milpa/commands/itself/create.yaml
+++ b/.milpa/commands/itself/create.yaml
@@ -15,8 +15,10 @@ options:
     description: Create an empty, executable command. Useful when you'd like using something other than bash.
   config-format:
     description: The configuration format to use to describe this command
-    values: [yaml]
+    values: {static: [yaml] }
     default: yaml
   repo:
     type: string
     description: a path to the milpa repo to create this command in. By default, the nearest .milpa directory from `pwd` and up.
+    values: {dirs: ""}
+

--- a/.milpa/commands/itself/docs/create.yaml
+++ b/.milpa/commands/itself/docs/create.yaml
@@ -13,3 +13,5 @@ options:
   repo:
     type: string
     description: a path to the milpa repo to create this doc in. By default, the nearest .milpa directory from `pwd` and up.
+    values: {dirs: ""}
+

--- a/.milpa/commands/itself/docs/html.yaml
+++ b/.milpa/commands/itself/docs/html.yaml
@@ -7,7 +7,7 @@ arguments:
   - name: action
     description: the action to take with documentation
     default: serve
-    values: [serve, write]
+    values: {static: [serve, write] }
 options:
   image:
     default: ghcr.io/unrob/milpa/docs:latest
@@ -18,6 +18,7 @@ options:
   to:
     default: ./dist/
     description: Where to write docs to, when **ACTION** is `write`
+    values: {dirs: ""}
   hostname:
     default: milpa.dev
     description: The hostname to set as base for the rendered docs

--- a/.milpa/commands/itself/repo/install.yaml
+++ b/.milpa/commands/itself/repo/install.yaml
@@ -6,12 +6,13 @@ description: |
   - In the `$MILPA_ROOT` (by default, /usr/local/lib/milpa), if `--global` is specified, or
   - In `$XDG_DATA_HOME/milpa` folder, if `--user` is specified.
 
-  Repos will be fetched from the `.milpa` subdirectory of `SOURCE`, which must be an URL as specified by [go-getter](https://github.com/hashicorp/go-getter#url-format). Basically, an https, git, hg, s3 or gcs URL.
+  Repos will be fetched from the `.milpa` subdirectory of `SOURCE`, which must be an URL as specified by [go-getter](https://github.com/hashicorp/go-getter#url-format). Basically, an https, git, hg, s3 or gcs URL. If `SOURCE` is a path to a local directory on the system, it'll be symlinked to the `TARGET` accordingly.
 
   ### Examples
 
   - `github.com/unRob/milpa` would download the `.milpa` folder from the `unRob/milpa` github repo, using **http**, and prompting for credentials for private repos.
   - `git::ssh://git@github.com/unRob/milpa.git//internal` would download the `internal/.milpa` folder from the `unRob/milpa` github repo using **ssh credentials**, useful for skipping credential prompts for private repos
+  - `~/.dotfiles` would symlink `$HOME/.dotfiles/.milpa` to the target. An alternative to this is to set `MILPA_PATH` to `$HOME/.dotfiles` (see [`milpa help docs milpa environment`](/.milpa/docs/milpa/environment.md))
 
 arguments:
   - name: source
@@ -19,6 +20,7 @@ arguments:
     required: true
   - name: target
     description: The path where to place the resulting `.milpa` folder in
+    values: {dirs: ""}
 options:
   global:
     short-name: g

--- a/.milpa/commands/itself/repo/list.sh
+++ b/.milpa/commands/itself/repo/list.sh
@@ -12,12 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+MILPA_REPOS_USER="${XDG_DATA_HOME:-$HOME}/.local/share/milpa/repos"
+MILPA_REPOS_GLOBAL="${MILPA_ROOT}/repos"
+
 function print_repo() {
+  local src
   if [[ "$MILPA_OPT_PATHS_ONLY" ]]; then
     echo "$1"
-  else
-    echo "$(@milpa.fmt bold "$1") - $(cat "$1/downloaded-from")"
+    return
   fi
+
+  if [[ -L "$1" ]]; then
+    src="$(readlink "$1")"
+  elif [[ "$1" != "${MILPA_REPOS_USER}/"* ]] && [[ "$1" != "${MILPA_REPOS_GLOBAL}/"* ]]; then
+    src="from \$MILPA_PATH"
+  else
+    src="$(cat "$1/downloaded-from")"
+  fi
+  echo "$(@milpa.fmt bold "$1") - $src"
 }
 
 [[ ! "$MILPA_OPT_PATHS_ONLY" ]] && echo "$(@milpa.fmt inverted " Local repos "): $MILPA_REPOS_USER"

--- a/.milpa/commands/itself/repo/uninstall.sh
+++ b/.milpa/commands/itself/repo/uninstall.sh
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 @milpa.log info "Removing $(@milpa.fmt bold "$MILPA_ARG_PATH")"
+if [[ -L "$MILPA_ARG_PATH" ]]; then
+  rm -f "$MILPA_ARG_PATH"
+else
+  rm -rf "$MILPA_ARG_PATH"
+fi
+
 if [[ -f "$MILPA_ARG_PATH/hooks/post-uninstall.sh" ]]; then
   @milpa.log info "Running post-uninstall hook"
   # run in a subshell so we don't care if it uninstall hook does weird stuff
@@ -22,4 +28,4 @@ if [[ -f "$MILPA_ARG_PATH/hooks/post-uninstall.sh" ]]; then
   ) || @milpa.log warning "Could not run post-uninstall hook to completion"
 fi
 
-rm -rf "$MILPA_ARG_PATH"
+@milpa.log complete "$MILPA_ARG_PATH uninstalled"

--- a/.milpa/commands/itself/repo/uninstall.yaml
+++ b/.milpa/commands/itself/repo/uninstall.yaml
@@ -5,4 +5,5 @@ arguments:
   - name: path
     description: The repo path to uninstall
     required: true
-    values-subcommand: itself repo list --paths-only
+    values:
+      milpa: itself repo list --paths-only

--- a/.milpa/commands/itself/upgrade.yaml
+++ b/.milpa/commands/itself/upgrade.yaml
@@ -1,4 +1,3 @@
-summary: Does a thing
+summary: Upgrades milpa to the latest available version
 description: |
-  Longer description of how it does the thing
-# see `milpa help docs command spec` for all the options
+  If a new version is available, this command will download and install it.

--- a/.milpa/docs/milpa/command/spec.md
+++ b/.milpa/docs/milpa/command/spec.md
@@ -34,12 +34,26 @@ arguments:
   - name: increment
     # arguments require a description
     descrption: the increment to apply to the last git version
-    # arguments can be validated to be part of a static set of values
-    values: [micro, patch, minor, major]
-    # commands may request values for validation dynamically by reading the
-    # lines printed by running another milpa subcommand.
-    # arguments may have `values` or `values-subcommand`, but not both.
-    values-subcommand: scm versions
+    # argument values can come from many sources:
+    # dirs, files, milpa, script and static
+    values:
+      # autocompletes directory names only, if a prefix is passed
+      # then it'll be used as a prefix to search from
+      dirs: "prefix"
+      # autocompletes files with the given extensions, if any
+      files: [yaml, json, hcl]
+      # milpa runs the subcommand and returns an option for every line of stdout
+      milpa: "itself repo list"
+      # script runs the provided command with `bash -c "$script"` and returns an
+      # option for every line of stdout
+      script: "git tag -l"
+      # arguments can be validated to be part of a static set of values
+      static: [micro, patch, minor, major]
+      # when using script or milpa values, wait at most this
+      # amount of seconds before giving up
+      timeout: 10
+      # only suggest these as autocompletions but don't validate them before running
+      suggest-only: true
     # arguments can have a default
     default: patch
     # or be required, but not have a default and be required at the same time.
@@ -61,8 +75,25 @@ options:
     # Sometimes, very commonly used flags might benefit from setting a short name
     # in this case, users would be able to use `-s calver`
     short-name: s
-    # options can also be validated against a set of values
-    values: [semver, calver]
+    # option values can come from many sources as well!
+    values:
+      # autocompletes directory names only, if a prefix is passed
+      # then it'll be used as a prefix to search from
+      dirs: "prefix"
+      # autocompletes files with the given extensions, if any
+      files: [yaml, json, hcl]
+      # milpa runs the subcommand and returns an option for every line of stdout
+      milpa: "itself repo list"
+      # script runs the provided command with `bash -c "$script"` and returns an
+      # option for every line of stdout
+      script: "git tag -l"
+      # arguments can be validated to be part of a static set of values
+      static: [micro, patch, minor, major]
+      # when using script or milpa values, wait at most this
+      # amount of seconds before giving up
+      timeout: 10
+      # only suggest these as autocompletions but don't validate them before running
+      suggest-only: true
     # and they may have defaults
     default: semver
     # or be required, but not have a default and be required at the same time.

--- a/.milpa/docs/milpa/repo/docs.md
+++ b/.milpa/docs/milpa/repo/docs.md
@@ -6,4 +6,4 @@ description: Render markdown docs to the terminal or browser
 
 Same docs are rendered to HTML, using the [`milpa itself docs html`](/.milpa/commands/itself/docs) command.
 
-These docs are brought to you courtesy of the recursive department of departamental recursiveness.
+These docs are brought to you courtesy of the **Recursive Department of Departamental Recursiveness**.

--- a/.milpa/docs/milpa/repo/hooks.md
+++ b/.milpa/docs/milpa/repo/hooks.md
@@ -12,7 +12,6 @@ This hook is run whenever `milpa itself shell init` is called. Its purpose is to
 
 This hook runs before invoking any command from your repo, and may be useful to do additional validations or checks before actually calling any of your commands. The full [environment](/.milpa/docs/milpa/environment.md) is available for this hook. This hook must be a bash shell script with an `.sh` extension.
 
-
 ## `post-install.sh`
 
 This hook is run after `milpa itself repo install` to bootstrap the installation of a remote repository (see [`milpa itself repo install`](/.milpa/commands/itself/repo/install.md)). This hook must be a bash shell script with an `.sh` extension.

--- a/.milpa/util/user-input.sh
+++ b/.milpa/util/user-input.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright © 2021 Roberto Hidalgo <milpa@un.rob.mx>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function @milpa.ask () {
+  local prompt default result
+  prompt="$1"
+  if [[ "$2" ]]; then
+    default="$2"
+    prompt="$prompt [default: $default]"
+  fi
+  read -re -p "$prompt " result
+
+  if [[ "$result" ]] || [[ "$default" ]]; then
+    echo "${result:-$default}"
+  else
+    @milpa.warning "No value was entered, please try again."
+    @ask "$prompt" "$result" "$default"
+  fi
+}
+
+function @milpa.confirm () {
+  read -r -p "$1${1:+ }Enter 'y' to continue: " -n 1
+  [[ ! $REPLY =~ ^[Yy]$ ]]
+}
+
+function @milpa.select () {
+  local options
+  IFS=$'\n' read -r -d '' -a options <<<"$1"
+  option_count=${#options[*]}
+
+  PS3="Select an option (1-$(( option_count+1 ))): "
+  select opt in "${options[@]}" "Quit"; do
+    if [[ "$opt" == "Quit" ]] || [[ $REPLY == "$(( option_count + 1 ))" ]]; then
+      return 1
+    fi
+
+    if [[ "$REPLY" != "" ]] && [[ "$REPLY" -gt 0 ]] && [[ "$REPLY" -le "$option_count" ]]; then
+      echo "${opt}"
+      break
+    fi
+    >&2 echo "No such option, try again"
+  done
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,3 @@
 <!-- this changelog is generated with `milpa cl update` -->
 Milpa follows the [semver 2.0.0](https://semver.org/spec/v2.0.0.html) specification.
 
-# [Upcoming](https://github.com/unRob/milpa/compare/dfa152673d41c22f7a99fd4a78641de9a65fdff1...HEAD)
-
-### 🌱 Features
-
-- (dfa152) Argument and flag run-time validation, so your command can focus on using them.
-- (dfa152) Command line argument, flag autocomplete for your commands on bash, zsh and fish. Completions can come from other commands.
-- (dfa152) Don't wanna write stuff over and over again? `milpa itself repo install` will come in handy to install remote milpa repos.
-- (dfa152) Drop your commands and specs in your project's `.milpa` folder, group them in folders and nest them, they'll become callable based on their path.
-- (dfa152) Needs bash, old ones work fine! Companion binary does the argument parsing and fancy rendering heavy lifting, available wherever golang builds for.
-- (dfa152) Readable `--help` on your terminal, searchable help on your browser. Same for docs that go along your commands.
-
----

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,18 @@
 curl -L https://milpa.dev/install.sh | bash -
 git clone git@github.com:/unRob/milpa.git
 cd milpa
-MILPA_ROOT=$(pwd) ./milpa setup
+MILPA_ROOT=$(pwd) ./milpa dev setup
 ```
 
 ## General flow
 
 ```sh
 eval "$(milpa dev env)"
+# then you're good to
 milpa dev lint [go|shell]
 milpa dev test [integration|unit]
+# or all in one go
+milpa dev ci
 ```
 
 Remember to add notes to the changelog if making user-facing changes!

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [`milpa`](https://milpa.dev) is a command-line tool to care for one's own garden of scripts, its name comes from "milpa", an agricultural method that combines multiple crops in close proximity
 
+For a brief intro to get started, check out [milpa help docs milpa quick-guide](/.milpa/docs/milpa/quick-guide.md).
+
 ```sh
 # install on mac and linux with:
 curl -L https://milpa.dev/install.sh | bash -
@@ -20,8 +22,6 @@ There's [a few reasons why](/.milpa/docs/milpa/alternatives.md) you and your tea
 Your milpa repos will contain **commands** and their corresponding specs, among other things. These can be executables written in whatever language you want, or bash shell scripts. Get the full story with [milpa help docs milpa command](/.milpa/docs/milpa/command/index.md)
 
 ## Enough words, show me some code
-
-For a brief intro to get started, check out [milpa help docs milpa quick-guide](/.milpa/docs/milpa/quick-guide.md).
 
 ```sh
 # milpa is a program you run

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,69 @@
+// Copyright © 2021 Roberto Hidalgo <milpa@un.rob.mx>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package constants
+
+import (
+	"regexp"
+)
+
+const Milpa = "milpa"
+const HelpCommandName = "help"
+
+// Environment Variables.
+const EnvVarHelpUnstyled = "MILPA_PLAIN_HELP"
+const EnvVarHelpStyle = "MILPA_HELP_STYLE"
+const EnvVarMilpaRoot = "MILPA_ROOT"
+const EnvVarMilpaPath = "MILPA_PATH"
+const EnvVarMilpaVerbose = "MILPA_VERBOSE"
+const EnvVarMilpaUnstyled = "NO_COLOR"
+const EnvVarCompaOut = "COMPA_OUT"
+const EnvVarDebug = "DEBUG"
+const EnvVarValidationDisabled = "MILPA_SKIP_VALIDATION"
+
+var EnvFlagNames = map[string]string{"no-color": "NO_COLOR", "silent": "MILPA_SILENT", "verbose": "MILPA_VERBOSE"}
+
+// Folder structure.
+const RepoRoot = ".milpa"
+const RepoCommandFolderName = "commands"
+const RepoCommands = ".milpa/commands"
+const RepoDocsFolderName = "docs"
+const RepoDocsTemplateFolderName = ".template"
+const RepoDocs = ".milpa/docs"
+
+// Output variable prefixes.
+const OutputPrefixArg = "MILPA_ARG_"
+const OutputPrefixOpt = "MILPA_OPT_"
+const OutputCommandName = "MILPA_COMMAND_NAME"
+const OutputCommandKind = "MILPA_COMMAND_KIND"
+const OutputCommandRepo = "MILPA_COMMAND_REPO"
+const OutputCommandPath = "MILPA_COMMAND_PATH"
+
+var OutputPrefixPattern = regexp.MustCompile(`\$\{?[#!]?MILPA_((OPT|ARG)_([0-9a-zA-Z_]+))`)
+
+// Exit statuses
+// see man sysexits || grep "#define EX" /usr/include/sysexits.h
+// and https://tldp.org/LDP/abs/html/exitcodes.html
+
+// 0 means everything is fine.
+const ExitStatusOk = 0
+
+// 42 provides answers to life, the universe and everything; also, renders help.
+const ExitStatusRenderHelp = 42
+
+// 64 bad arguments
+// EX_USAGE The command was used incorrectly, e.g., with the wrong number of arguments, a bad flag, a bad syntax in a parameter, or whatever.
+const ExitStatusUsage = 64
+
+// EX_SOFTWARE An internal software error has been detected. This should be limited to non-operating system related errors as possible.
+const ExitStatusProgrammerError = 70
+const ExitStatusNotFound = 127

--- a/internal/environment.go
+++ b/internal/environment.go
@@ -19,16 +19,15 @@ import (
 	"github.com/alessio/shellescape"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	_c "github.com/unrob/milpa/internal/constants"
 )
-
-var customNames = map[string]string{"no-color": "NO_COLOR", "silent": "MILPA_SILENT", "verbose": "MILPA_VERBOSE"}
 
 func (cmd *Command) ToEval(args []string, flags *pflag.FlagSet) (string, error) {
 	output := []string{
-		fmt.Sprintf("export MILPA_COMMAND_NAME=%s", shellescape.Quote(cmd.FullName())),
-		fmt.Sprintf("export MILPA_COMMAND_KIND=%s", shellescape.Quote(cmd.Meta.Kind)),
-		fmt.Sprintf("export MILPA_COMMAND_REPO=%s", shellescape.Quote(cmd.Meta.Repo)),
-		fmt.Sprintf("export MILPA_COMMAND_PATH=%s", shellescape.Quote(cmd.Meta.Path)),
+		fmt.Sprintf("export %s=%s", _c.OutputCommandName, shellescape.Quote(cmd.FullName())),
+		fmt.Sprintf("export %s=%s", _c.OutputCommandKind, shellescape.Quote(cmd.Meta.Kind)),
+		fmt.Sprintf("export %s=%s", _c.OutputCommandRepo, shellescape.Quote(cmd.Meta.Repo)),
+		fmt.Sprintf("export %s=%s", _c.OutputCommandPath, shellescape.Quote(cmd.Meta.Path)),
 	}
 
 	err := cmd.Options.ToEnv(&output, flags)

--- a/internal/exec.go
+++ b/internal/exec.go
@@ -1,0 +1,66 @@
+// Copyright © 2021 Roberto Hidalgo <milpa@un.rob.mx>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package internal
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	os_exec "os/exec"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	_c "github.com/unrob/milpa/internal/constants"
+)
+
+func exec(name string, subcommand string, timeout time.Duration) ([]string, cobra.ShellCompDirective, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout*time.Second)
+	defer cancel() // The cancel should be deferred so resources are cleaned up
+
+	executable := ""
+	var args []string
+	if name == "@bash" {
+		executable = "/bin/bash"
+		args = []string{"-c", subcommand}
+		logrus.Debugf("executing bash %s", args)
+	} else {
+		executable = _c.Milpa
+		args = strings.Split(subcommand, " ")
+		logrus.Debugf("executing sub command %s %s", executable, args)
+	}
+
+	cmd := os_exec.CommandContext(ctx, executable, args...) // #nosec G204
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Env = os.Environ()
+	err := cmd.Run() // nolint:ifshort
+
+	if ctx.Err() == context.DeadlineExceeded {
+		fmt.Println("Sub-command timed out")
+		logrus.Debugf("timeout running %s %s: %s", executable, args, stdout.String())
+		return []string{}, cobra.ShellCompDirectiveError, fmt.Errorf("could not resolve valid arguments before timeout")
+	}
+
+	if err != nil {
+		logrus.Debugf("error running %s %s: %s", executable, args, err)
+		return []string{}, cobra.ShellCompDirectiveError, BadArguments{fmt.Sprintf("could not validate argument %s, sub-command <%s> failed: %s", name, subcommand, err)}
+	}
+
+	logrus.Debugf("done running %s %s: %s", executable, args, stdout.String())
+	return strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n"), 0, nil
+}

--- a/internal/find_test.go
+++ b/internal/find_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	. "github.com/unrob/milpa/internal"
+	"github.com/unrob/milpa/internal/runtime"
 )
 
 var fsBase = "usr/local/milpa"
@@ -87,7 +88,7 @@ func setupFS(filenames []string, pool map[string]*fstest.MapFile) *fstest.MapFS 
 		fs[fsBase+"/.milpa/commands/"+name] = pool[name]
 	}
 
-	MilpaPath = []string{fsBase + "/.milpa"}
+	runtime.MilpaPath = []string{fsBase + "/.milpa"}
 	DefaultFS = &fs
 	return &fs
 }

--- a/internal/options.go
+++ b/internal/options.go
@@ -1,0 +1,140 @@
+// Copyright © 2021 Roberto Hidalgo <milpa@un.rob.mx>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package internal
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alessio/shellescape"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	_c "github.com/unrob/milpa/internal/constants"
+	runtime "github.com/unrob/milpa/internal/runtime"
+)
+
+// Options is a map of name to Option.
+type Options map[string]*Option
+
+// ToEnv writes shell variables to dst.
+func (opts *Options) ToEnv(dst *[]string, flags *pflag.FlagSet) (err error) {
+	errors := []string{}
+	flags.VisitAll(func(f *pflag.Flag) {
+		name := f.Name
+		//nolint:goconst
+		if name == "help" {
+			return
+		}
+		envName := ""
+		value := f.Value.String()
+
+		if cname, ok := _c.EnvFlagNames[name]; ok {
+			if value == "false" {
+				return
+			}
+			envName = cname
+		} else {
+			envName = fmt.Sprintf("%s%s", _c.OutputPrefixOpt, strings.ToUpper(strings.ReplaceAll(name, "-", "_")))
+		}
+
+		switch f.Value.Type() {
+		case "bool":
+			if val, err := flags.GetBool(f.Name); err == nil && !val {
+				value = ""
+			} else {
+				value = "true"
+			}
+		default:
+			oopts := *opts
+			opt, ok := oopts[name]
+			if value != "" && ok && opt.Validates() && runtime.ValidationEnabled() {
+				logrus.Debugf("Validating option %s", name)
+				values, _, verr := opt.Resolve()
+				if verr != nil {
+					errors = append(errors, err.Error())
+					return
+				}
+
+				if !contains(values, value) {
+					errors = append(errors,
+						fmt.Sprintf("invalid value for --%s: %s. Valid values are %s", name, value, strings.Join(values, ", ")),
+					)
+				}
+			}
+			logrus.Debugf("flag %s is a %s", f.Name, f.Value.Type())
+		}
+
+		value = shellescape.Quote(value)
+		*dst = append(*dst, fmt.Sprintf("export %s=%s", envName, value))
+	})
+
+	if len(errors) > 0 {
+		return BadArguments{strings.Join(errors, ". ")}
+	}
+	return nil
+}
+
+// Option represents a command line flag.
+type Option struct {
+	ShortName   string       `yaml:"short-name"`
+	Type        ValueType    `yaml:"type" validate:"omitempty,oneof=string bool"`
+	Description string       `yaml:"description" validate:"required"`
+	Default     interface{}  `yaml:"default"`
+	Values      *ValueSource `yaml:"values" validate:"omitempty"`
+}
+
+// Validates tells if the user-supplied value needs validation.
+func (opt *Option) Validates() bool {
+	return opt.Values.Validates()
+}
+
+// providesAutocomplete tells if this option provides autocomplete values.
+func (opt *Option) providesAutocomplete() bool {
+	return opt.Values != nil
+}
+
+// Resolve returns autocomplete values for an option.
+func (opt *Option) Resolve() (values []string, flag cobra.ShellCompDirective, err error) {
+	if opt.Values != nil {
+		return opt.Values.Resolve()
+	}
+
+	return
+}
+
+// CompletionFunction is called by cobra when asked to complete an option.
+func (opt *Option) CompletionFunction(cmd *cobra.Command, args []string, toComplete string) (values []string, flag cobra.ShellCompDirective) {
+
+	if !opt.providesAutocomplete() {
+		flag = cobra.ShellCompDirectiveError
+		return
+	}
+
+	var err error
+	values, flag, err = opt.Resolve()
+	if err != nil {
+		return values, cobra.ShellCompDirectiveError
+	}
+
+	if toComplete != "" {
+		filtered := []string{}
+		for _, value := range values {
+			if strings.HasPrefix(value, toComplete) {
+				filtered = append(filtered, value)
+			}
+		}
+		values = filtered
+	}
+	return values, flag
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,0 +1,50 @@
+// Copyright © 2021 Roberto Hidalgo <milpa@un.rob.mx>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	_c "github.com/unrob/milpa/internal/constants"
+)
+
+func DoctorModeEnabled() bool {
+	return len(os.Args) >= 2 && (os.Args[1] == "__doctor" || (len(os.Args) > 2 && (os.Args[1] == "itself" && os.Args[2] == "doctor")))
+}
+
+func ValidationEnabled() bool {
+	return os.Getenv(_c.EnvVarValidationDisabled) != "1"
+}
+
+func VerboseEnabled() bool {
+	return os.Getenv(_c.EnvVarMilpaVerbose) != ""
+}
+
+func ColorEnabled() bool {
+	return os.Getenv(_c.EnvVarMilpaUnstyled) == "" && os.Getenv(_c.EnvVarHelpUnstyled) == ""
+}
+
+func UnstyledHelpEnabled() bool {
+	return os.Getenv(_c.EnvVarHelpUnstyled) == "enabled"
+}
+
+var MilpaPath = strings.Split(os.Getenv(_c.EnvVarMilpaPath), ":")
+
+func CheckMilpaPathSet() error {
+	if len(MilpaPath) == 0 {
+		return fmt.Errorf("no %s set on the environment", _c.EnvVarMilpaPath)
+	}
+	return nil
+}

--- a/internal/value.go
+++ b/internal/value.go
@@ -1,0 +1,97 @@
+// Copyright © 2021 Roberto Hidalgo <milpa@un.rob.mx>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package internal
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// ValueType represent the kinds of values for an argument or option.
+type ValueType string
+
+const (
+	// ValueTypeDefault is the empty string, maps to ValueTypeString.
+	ValueTypeDefault ValueType = ""
+	// ValueTypeString a value treated like a string.
+	ValueTypeString ValueType = "string"
+	// ValueTypeBoolean is a value treated like a boolean.
+	ValueTypeBoolean ValueType = "bool"
+)
+
+// ValueSource represents the source for an auto-completed and/or validated option/argument.
+type ValueSource struct {
+	// Directories prompts for directories with the given prefix.
+	Directories *string `yaml:"dirs" validate:"omitempty,excluded_with=Files Script Static Milpa"`
+	// Files prompts for files with the given extensions
+	Files *[]string `yaml:"files" validate:"omitempty,excluded_with=Directories Script Static Milpa"`
+	// Script runs the provided command with `bash -c "$script"` and returns an option for every line of stdout.
+	Script string `yaml:"script" validate:"omitempty,excluded_with=Directories Files Static Milpa"`
+	// Static returns the given list.
+	Static *[]string `yaml:"static" validate:"omitempty,excluded_with=Directories Files Script Milpa"`
+	// Milpa runs a subcommand and returns an option for every line of stdout.
+	Milpa string `yaml:"milpa" validate:"omitempty,excluded_with=Directories Files Script Static"`
+	// Timeout is the maximum amount of time milpa will wait for a Script or Milpa command before giving up on completions/validations.
+	Timeout int `yaml:"timeout" validate:"omitempty,excluded_with=Directories Files Static"`
+	// Suggestion if provided will only suggest autocomplete values but will not perform validation of a given value
+	Suggestion bool `yaml:"suggest-only" validate:"omitempty"`
+	computed   *[]string
+	flag       cobra.ShellCompDirective
+}
+
+// Validates tells if a value needs to be validated.
+func (vs *ValueSource) Validates() bool {
+	if vs.Directories != nil || vs.Files != nil {
+		return false
+	}
+
+	return !vs.Suggestion
+}
+
+// Resolve returns the values for autocomplete and validation.
+func (vs *ValueSource) Resolve() (values []string, flag cobra.ShellCompDirective, err error) {
+	if vs.computed != nil {
+		return *vs.computed, vs.flag, nil
+	}
+
+	if vs.Timeout == 0 {
+		vs.Timeout = 5
+	}
+
+	flag = cobra.ShellCompDirectiveDefault
+	timeout := time.Duration(vs.Timeout)
+
+	switch {
+	case vs.Milpa != "":
+		values, flag, err = exec("unknown", vs.Milpa, timeout)
+	case vs.Static != nil:
+		values = *vs.Static
+	case vs.Files != nil:
+		flag = cobra.ShellCompDirectiveFilterFileExt
+		values = *vs.Files
+	case vs.Directories != nil:
+		flag = cobra.ShellCompDirectiveFilterDirs
+		values = []string{*vs.Directories}
+	case vs.Script != "":
+		values, flag, err = exec("@bash", vs.Script, timeout)
+	}
+
+	if err != nil {
+		return
+	}
+	vs.computed = &values
+	vs.flag = flag
+
+	return values, flag, err
+}

--- a/repos/internal/commands/cl/add.sh
+++ b/repos/internal/commands/cl/add.sh
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+@milpa.load_util user-input
 
 entry="${MILPA_ARG_MESSAGE[*]}"
 if [[ "$entry" == "" || "$entry" == "-" ]]; then
   if [[ -t 1 ]]; then
-    read -r -p "Enter the message for this <$MILPA_ARG_KIND>: " entry
+    entry=$(@milpa.ask "Enter the message for this <$MILPA_ARG_KIND>:")
   else
     entry=$(cat)
   fi

--- a/repos/internal/commands/cl/add.yaml
+++ b/repos/internal/commands/cl/add.yaml
@@ -5,12 +5,13 @@ arguments:
   - name: kind
     description: The kind of entry to create
     values:
-      - breaking-change
-      - bug
-      - deprecation
-      - feature
-      - improvement
-      - note
+      static:
+        - breaking-change
+        - bug
+        - deprecation
+        - feature
+        - improvement
+        - note
     required: true
   - name: message
     variadic: true

--- a/repos/internal/commands/cl/drop.yaml
+++ b/repos/internal/commands/cl/drop.yaml
@@ -9,9 +9,10 @@ options:
   kind:
     description: If specified, the kind of entry to drop
     values:
-      - breaking-change
-      - bug
-      - deprecation
-      - feature
-      - improvement
-      - note
+      static:
+        - breaking-change
+        - bug
+        - deprecation
+        - feature
+        - improvement
+        - note

--- a/repos/internal/commands/cl/show.yaml
+++ b/repos/internal/commands/cl/show.yaml
@@ -6,8 +6,5 @@ arguments:
     description: the version to generate release notes for
     default: HEAD
 options:
-  header:
-    type: bool
-    description: Print a markdown header
   header-offset:
     description: Increase header levels by this offset

--- a/repos/internal/commands/dev/build.sh
+++ b/repos/internal/commands/dev/build.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 if [[ "$MILPA_ARG_VERSION" == "auto" ]]; then
-  VERSION="$(git describe)"
+  VERSION="$(git describe --long)"
 else
   VERSION="$MILPA_ARG_VERSION"
 fi

--- a/repos/internal/commands/dev/ci.sh
+++ b/repos/internal/commands/dev/ci.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+milpa dev lint go && milpa dev test unit
+goOk=$?
+
+milpa dev lint shell
+shellOk="$?"
+integrationOk=1
+if [[ "$goOk" -eq 0 ]]; then
+  milpa dev build
+  milpa dev test integration
+  integrationOk="$?"
+fi
+
+[[ "${shellOk}${goOk}${integrationOk}" == "000" ]]

--- a/repos/internal/commands/dev/ci.yaml
+++ b/repos/internal/commands/dev/ci.yaml
@@ -1,0 +1,3 @@
+summary: Lints and tests milpa
+description: |
+  runs `milpa dev lint {shell,go}` and `milpa dev test {unit,integration}`

--- a/repos/internal/commands/dev/setup.sh
+++ b/repos/internal/commands/dev/setup.sh
@@ -35,7 +35,9 @@ if [[ "$ASDF_DIR" ]]; then
 fi
 
 @milpa.log info "Installing go packages"
+cd || @milpa.fail "could not cd into home"
 command -v gotestsum >/dev/null || go get -u gotest.tools/gotestsum
 command -v gox >/dev/null || go get -u github.com/mitchellh/gox
-command -v gotestsum >/dev/null || go get -u gotest.tools/gotestsum
+command -v golangci-lint >/dev/null || go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+popd || @milpa.fail "could not return to previous dir"
 go mod tidy

--- a/repos/internal/commands/dev/test/integration.yaml
+++ b/repos/internal/commands/dev/test/integration.yaml
@@ -9,4 +9,4 @@ options:
   format:
     description: the format for test output
     default: auto
-    values: [pretty, auto, tap]
+    values: {static: [pretty, auto, tap] }

--- a/repos/internal/commands/release/build.yaml
+++ b/repos/internal/commands/release/build.yaml
@@ -16,12 +16,23 @@ arguments:
   - name: version
     description: The semver number to build
     required: true
+    values:
+      script: git tag -l
   - name: hostname
     description: the hostname where documentation and install scripts will be served under
     default: milpa.dev
   - name: targets
     description: the targets to build for
     variadic: true
+    values:
+      static:
+        - auto
+        - linux/amd64
+        - linux/arm64
+        - linux/arm
+        - linux/mips
+        - darwin/amd64
+        - darwin/arm64
 options:
   output:
     description: the path where to put built assets in

--- a/repos/internal/commands/release/create.sh
+++ b/repos/internal/commands/release/create.sh
@@ -48,9 +48,7 @@ if [[ "$MILPA_OPT_PRE" ]]; then
 fi
 
 @milpa.log info "Creating release with version $(@milpa.fmt inverted "$next")"
-read -r -p "Enter 'y' to continue: " -n 1
-echo
-[[ ! $REPLY =~ ^[Yy]$ ]] && @milpa.fail "Refusing to continue, expected 'y', got <$REPLY>"
+@milpa.confirm "Proceed with release?" || @milpa.fail "Refusing to continue, got <$REPLY>"
 @milpa.log success "Continuing with release"
 
 

--- a/repos/internal/commands/release/create.yaml
+++ b/repos/internal/commands/release/create.yaml
@@ -3,5 +3,6 @@ description: |
   Automation might trigger a release if github is in a good mood
 options:
   pre:
-    values: [alpha, beta, rc]
+    values:
+      static: [alpha, beta, rc]
     description: create a pre-release

--- a/repos/internal/commands/release/docs-image.yaml
+++ b/repos/internal/commands/release/docs-image.yaml
@@ -9,6 +9,9 @@ options:
   skip-publish:
     type: bool
     description: If enabled, the image will be created but not pushed
+  skip-latest:
+    type: bool
+    description: If enabled, the image will be pushed but not tagged as latest
   docker-repo:
     description: The docker repo url to push to
     default: ghcr.io/unrob/milpa/docs


### PR DESCRIPTION
- let users install local repos as symlinks
- add user input utils with select, ask and confirm
- golangci harder
- reorganize go code, maybe i do want milpa to have multiple names after all?
- remove `(argument|option).(values|values-subcommand)` and merge them under a new `values` dictionary
- autocompletion of variadic arguments
- autocompletion from files, directories and arbitrary bash scripts
- reliable order of commands (according to MILPA_PATH and then alphabetically) which also gets us "index" commands (`milpa test` and `milpa test shell`) for free*!

\* with the caveat that index commands will throw milpa into an infinite loop if they call a non-existant child command